### PR TITLE
FIX: problem with **kwargs while init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "allenai-common"
-version = "1.1.1"
+version = "1.1.2"
 description = "Params, FromParams, Registrable, Lazy classes from AllenNLP"
 authors = ["Ivan Fursov <fursovia@gmail.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
Way to reproduce current behavior with error:
```
from allenai_common import Registrable, Params
class A(Registrable):
    def __init__(self, a: int, b: str, **kwargs):
        self.a = a 
        self.b = b
@A.register("b")
class B(A):
    def __init__(self, a: int, b: str, **kwargs):
        self.a = a
        self.b = b
b = A.by_name("b").from_params(Params({"a": 1, "b": "4343"}))
```