### PR TITLE
Update overrides dependency to support python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/fursovia/allenai-common"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-overrides = "==3.1.0"
+overrides = ">=3.1.0"
 filelock = "^3.0.0"
 requests = "^2.18.0"
 tqdm = "^4.19.0"


### PR DESCRIPTION
* Package is not compatible with python 3.12 due to overrides package being fixed at 3.1.0